### PR TITLE
Add the ability to get the browser from an env. variable

### DIFF
--- a/app.js
+++ b/app.js
@@ -51,7 +51,9 @@ const signInHandler = async (argv) => {
       roleCredentials: { accessKeyId, secretAccessKey, sessionToken },
     } = await getCredentials(accessToken, accountId, roleName, region);
 
-    if (argv.web) {
+    if (argv.web && typeof process.env.BROWSER !== 'undefined') {
+      open(await getSigninUrl(accessKeyId, secretAccessKey, sessionToken), {app: process.env.BROWSER});
+    } else if (argv.web) {
       open(await getSigninUrl(accessKeyId, secretAccessKey, sessionToken));
     } else {
       console.log(

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -34,7 +34,11 @@ const requestToken = async ({ clientId, clientSecret }, startUrl, AWSClient) => 
     AWSClient
   );
   console.error(`Attempting to open: ${chalk.bold.yellow(verificationUriComplete)}`);
-  await open(verificationUriComplete);
+  if (typeof process.env.BROWSER !== 'undefined') {
+    await open(verificationUriComplete, {app: process.env.BROWSER});
+  } else {
+    await open(verificationUriComplete);
+  }
   await keypress("enter");
   const token = await createToken(clientId, clientSecret, deviceCode, AWSClient);
 


### PR DESCRIPTION
This is a proposal to have the ability to overwrite the default browser from the OS. If you like it, I'll also update the readme.

Let me know your thoughts.

**Some context:** On my setup I have to deal with multiple accounts for different applications, and therefore I'm using multiple browsers. One of my browsers (Firefox), I'm using to administer AWS, but I don't want to set this browser as default. Having the ability to set a "BROWSER" env. variable, allows me to use Firefox for the aws-sso-cli login process.